### PR TITLE
Make mips241 compilable on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,17 @@ build/
 *.swp
 *.rkt~
 compiled/
+src/common/mips241_export.h
+
+# visual studio
+CMakeSettings.json
+.vs/
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ the groundwork has been laid out.
 
 # Building
 
+## *NIX environments
+
 The project has external dependencies as git submodules. Use `--recursive`
 as a flag to `git clone`. If you have already cloned,
 ```sh
@@ -37,6 +39,13 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DSANITIZE_ADDRESS=on ..
 make
 ````
+
+## Windows with MSVC
+
+If you are using Visual Studio, open the project folder inside Visual Studio (make
+sure C++ build tools are installed), the software should automatically recognize
+it as a CMake project. Go to manage configurations, and check the "SANITIZE_ADDRESS"
+checkbox, then right click CMakeLists.txt -> build.
 
 # Install
 

--- a/src/common/defs.h
+++ b/src/common/defs.h
@@ -6,6 +6,13 @@
 
 #include <stdint.h>
 
+/* Windows dll needs this declaration for library export */
+#if (defined(_MSC_VER) || defined(__MINGW32__))
+    #define mips241_EXPORT __declspec(dllexport)
+#else
+    #define mips241_EXPORT
+#endif
+
 #define FUNC_ADD    0x20
 #define FUNC_SUB    0x22
 #define FUNC_MULTU  0x19

--- a/src/emulator/emulator.h
+++ b/src/emulator/emulator.h
@@ -11,14 +11,15 @@
 
 
 // Load a program from a FILE into the machine at the offset.
-void load_program(FILE *const file,
+mips241_EXPORT void load_program(FILE *const file,
                   Machine *const machine,
                   uint32_t offset);
 
 // Must call this function on startup to initialize things.
-void init_emulator(void);
+mips241_EXPORT void init_emulator(void);
 
 // Dump memory to the file
-void dump_memory(const Machine *const machine, const char *filename);
+mips241_EXPORT void dump_memory(const Machine *const machine,
+                  const char *filename);
 
 #endif

--- a/src/emulator/emulator.h
+++ b/src/emulator/emulator.h
@@ -11,15 +11,14 @@
 
 
 // Load a program from a FILE into the machine at the offset.
-mips241_EXPORT void load_program(FILE *const file,
-                  Machine *const machine,
-                  uint32_t offset);
+mips241_EXPORT void load_program(FILE *const file, Machine *const machine, 
+                                 uint32_t offset);
 
 // Must call this function on startup to initialize things.
 mips241_EXPORT void init_emulator(void);
 
 // Dump memory to the file
 mips241_EXPORT void dump_memory(const Machine *const machine,
-                  const char *filename);
+                                const char *filename);
 
 #endif

--- a/src/frontend/bindings.rkt
+++ b/src/frontend/bindings.rkt
@@ -10,6 +10,10 @@ Basically, the following files need to be "ported":
   - common/defs.h
 |#
 
+;; for windows, lib name does not have the lib-prefix
+(define mips241-libname
+    (if (eq? (system-type 'os) 'windows) "mips241" "libmips241"))
+
 (require ffi/unsafe
          ffi/unsafe/define
          ffi/unsafe/alloc
@@ -30,7 +34,7 @@ Basically, the following files need to be "ported":
 
 (define num-registers 32)
 (define-ffi-definer define-mips241
-  (ffi-lib "libmips241"
+  (ffi-lib mips241-libname
            #:get-lib-dirs get-paths-for-lib))
 
 ;; Types from C. These must match!

--- a/src/machine/decode.h
+++ b/src/machine/decode.h
@@ -10,6 +10,6 @@
 // Decode an instruction from a 32-bit word.
 // NOTE: This function does not check for a valid instruction.
 // The caller must check for a valid opcode in the return value.
-Instruction decode_instruction(uint32_t);
+mips241_EXPORT Instruction decode_instruction(uint32_t);
 
 #endif

--- a/src/machine/impl.h
+++ b/src/machine/impl.h
@@ -11,10 +11,10 @@
 struct Machine;
 
 // Interpet one instruction and advance the machine state
-EmulatorStatus step_machine(struct Machine *const machine);
+mips241_EXPORT EmulatorStatus step_machine(struct Machine *const machine);
 
 // Interpet as many instructions as we can until
 //   we are required to stop.
-EmulatorStatus step_machine_loop(struct Machine *const machine);
+mips241_EXPORT EmulatorStatus step_machine_loop(struct Machine *const machine);
 
 #endif

--- a/src/machine/machine.h
+++ b/src/machine/machine.h
@@ -7,6 +7,7 @@
 #define MACHINE_H__
 
 #include <stdint.h>
+#include "common/defs.h"
 
 #define NUM_WORDS_MEMORY 4194304 // 16 MB of RAM by default
 #define NUM_REGISTERS 32         // does not include pc, ir, lo, hi
@@ -26,17 +27,17 @@ typedef struct Machine {
 //   is given to the machine in bytes. Otherwise,
 //   the default amount of memory is used.
 // Requires: max_memory_bytes is divisible by 4
-Machine *init_machine(uint32_t max_memory_bytes);
+mips241_EXPORT Machine *init_machine(uint32_t max_memory_bytes);
 
 
 // Frees all memory associated with a Machine.
 // Requires: machine allocated with init_machine
 // Effects: memory freed
-void destroy_machine(Machine *machine);
+mips241_EXPORT void destroy_machine(Machine *machine);
 
 
 // Prints all registers to stderr.
 // Effects: output
-void m_print_registers(const Machine *const machine);
+mips241_EXPORT void m_print_registers(const Machine *const machine);
 
 #endif


### PR DESCRIPTION
This is a small change that makes the program compile on MSVC and run on Windows:

![Capture](https://user-images.githubusercontent.com/57923352/82090292-4e059800-96c3-11ea-9263-0de39e0c6ca8.PNG)

It adds a word before each function declaration, please see the commit message for details.